### PR TITLE
added ZMRANGE series

### DIFF
--- a/lua/SORTED_SETS_XP/3_ZMRANGEBYSCOREXP.lua
+++ b/lua/SORTED_SETS_XP/3_ZMRANGEBYSCOREXP.lua
@@ -8,12 +8,20 @@ local now = tonumber(redis.call('TIME')[1])
 local results = {}
 local k = ""
 local skip = false
+local expireAt = {}
+for i, v in ipairs(redis.pcall('ZRANGE', ZSET_EXPIREAT_KEY, 0, -1, "WITHSCORES")) do
+    if i % 2 == 1 then
+        k = v
+    else
+        expireAt[k]=v
+    end
+end
 
 for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
     if ARGV[1] == "WITHSCORES" then
         if i % 2 == 1 then
             k = v
-            if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, k)) < now then
+            if tonumber(expireAt[k]) < now then
                 redis.call('ZREM', KEYS[1], k)
                 redis.call('ZREM', ZSET_EXPIREAT_KEY, k)
                 skip = true
@@ -27,7 +35,7 @@ for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpac
             skip = false
         end
     else
-        if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, v)) < now then
+        if tonumber(expireAt[v]) < now then
             redis.call('ZREM', KEYS[1], v)
             redis.call('ZREM', ZSET_EXPIREAT_KEY, v)
         else

--- a/lua/SORTED_SETS_XP/3_ZMRANGEXP.lua
+++ b/lua/SORTED_SETS_XP/3_ZMRANGEXP.lua
@@ -1,6 +1,6 @@
 -- SORTED SETS with EXPIRE by member
--- ZRANGEBYSCOREXP key min max [WITHSCORES LIMIT offset count]
----- This command returns the members still alive between min and max
+-- ZRANGEXP key min max [WITHSCORES]
+---- This command returns the number of keys still alive between min and max
 
 local ZSET_EXPIREAT_KEY = KEYS[1]..".EXPIREAT"
 local now = tonumber(redis.call('TIME')[1])
@@ -8,12 +8,20 @@ local now = tonumber(redis.call('TIME')[1])
 local results = {}
 local k = ""
 local skip = false
+local expireAt = {}
+for i, v in ipairs(redis.pcall('ZRANGE', ZSET_EXPIREAT_KEY, 0, -1, "WITHSCORES")) do
+    if i % 2 == 1 then
+        k = v
+    else
+        expireAt[k]=v
+    end
+end
 
-for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
+for i, v in ipairs(redis.pcall('ZRANGE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
     if ARGV[1] == "WITHSCORES" then
         if i % 2 == 1 then
             k = v
-            if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, k)) < now then
+            if tonumber(expireAt[k]) < now then
                 redis.call('ZREM', KEYS[1], k)
                 redis.call('ZREM', ZSET_EXPIREAT_KEY, k)
                 skip = true
@@ -27,7 +35,7 @@ for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpac
             skip = false
         end
     else
-        if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, v)) < now then
+        if tonumber(expireAt[v]) < now then
             redis.call('ZREM', KEYS[1], v)
             redis.call('ZREM', ZSET_EXPIREAT_KEY, v)
         else

--- a/lua/SORTED_SETS_XP/3_ZREVMRANGEBYSCOREXP.lua
+++ b/lua/SORTED_SETS_XP/3_ZREVMRANGEBYSCOREXP.lua
@@ -1,5 +1,5 @@
 -- SORTED SETS with EXPIRE by member
--- ZRANGEBYSCOREXP key min max [WITHSCORES LIMIT offset count]
+-- ZREVRANGEBYSCOREXP key min max [WITHSCORES LIMIT offset count]
 ---- This command returns the members still alive between min and max
 
 local ZSET_EXPIREAT_KEY = KEYS[1]..".EXPIREAT"
@@ -8,12 +8,20 @@ local now = tonumber(redis.call('TIME')[1])
 local results = {}
 local k = ""
 local skip = false
+local expireAt = {}
+for i, v in ipairs(redis.pcall('ZRANGE', ZSET_EXPIREAT_KEY, 0, -1, "WITHSCORES")) do
+    if i % 2 == 1 then
+        k = v
+    else
+        expireAt[k]=v
+    end
+end
 
-for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
+for i, v in ipairs(redis.pcall('ZREVRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
     if ARGV[1] == "WITHSCORES" then
         if i % 2 == 1 then
             k = v
-            if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, k)) < now then
+            if tonumber(expireAt[k]) < now then
                 redis.call('ZREM', KEYS[1], k)
                 redis.call('ZREM', ZSET_EXPIREAT_KEY, k)
                 skip = true
@@ -27,7 +35,7 @@ for i, v in ipairs(redis.pcall('ZRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpac
             skip = false
         end
     else
-        if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, v)) < now then
+        if tonumber(expireAt[v]) < now then
             redis.call('ZREM', KEYS[1], v)
             redis.call('ZREM', ZSET_EXPIREAT_KEY, v)
         else

--- a/lua/SORTED_SETS_XP/3_ZREVRANGEBYSCOREXP.lua
+++ b/lua/SORTED_SETS_XP/3_ZREVRANGEBYSCOREXP.lua
@@ -8,20 +8,12 @@ local now = tonumber(redis.call('TIME')[1])
 local results = {}
 local k = ""
 local skip = false
-local expireAt = {}
-for i, v in ipairs(redis.pcall('ZRANGE', ZSET_EXPIREAT_KEY, 0, -1, "WITHSCORES")) do
-    if i % 2 == 1 then
-        k = v
-    else
-        expireAt[k]=v
-    end
-end
 
 for i, v in ipairs(redis.pcall('ZREVRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
     if ARGV[1] == "WITHSCORES" then
         if i % 2 == 1 then
             k = v
-            if tonumber(expireAt[k]) < now then
+            if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, k)) < now then
                 redis.call('ZREM', KEYS[1], k)
                 redis.call('ZREM', ZSET_EXPIREAT_KEY, k)
                 skip = true
@@ -35,7 +27,7 @@ for i, v in ipairs(redis.pcall('ZREVRANGEBYSCORE', KEYS[1], KEYS[2], KEYS[3], un
             skip = false
         end
     else
-        if tonumber(expireAt[v]) < now then
+        if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, v)) < now then
             redis.call('ZREM', KEYS[1], v)
             redis.call('ZREM', ZSET_EXPIREAT_KEY, v)
         else

--- a/lua/SORTED_SETS_XP/3_ZREVRANGEXP.lua
+++ b/lua/SORTED_SETS_XP/3_ZREVRANGEXP.lua
@@ -8,20 +8,12 @@ local now = tonumber(redis.call('TIME')[1])
 local results = {}
 local k = ""
 local skip = false
-local expireAt = {}
-for i, v in ipairs(redis.pcall('ZRANGE', ZSET_EXPIREAT_KEY, 0, -1, "WITHSCORES")) do
-    if i % 2 == 1 then
-        k = v
-    else
-        expireAt[k]=v
-    end
-end
 
 for i, v in ipairs(redis.pcall('ZREVRANGE', KEYS[1], KEYS[2], KEYS[3], unpack(ARGV))) do
     if ARGV[1] == "WITHSCORES" then
         if i % 2 == 1 then
             k = v
-            if tonumber(expireAt[k]) < now then
+            if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, k)) < now then
                 redis.call('ZREM', KEYS[1], k)
                 redis.call('ZREM', ZSET_EXPIREAT_KEY, k)
                 skip = true
@@ -35,7 +27,7 @@ for i, v in ipairs(redis.pcall('ZREVRANGE', KEYS[1], KEYS[2], KEYS[3], unpack(AR
             skip = false
         end
     else
-        if tonumber(expireAt[v]) < now then
+        if tonumber(redis.pcall('ZSCORE', ZSET_EXPIREAT_KEY, v)) < now then
             redis.call('ZREM', KEYS[1], v)
             redis.call('ZREM', ZSET_EXPIREAT_KEY, v)
         else

--- a/util_test.go
+++ b/util_test.go
@@ -13,7 +13,7 @@ func TestGetAllScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error connection to script, %v", err)
 	}
-	if len(scripts) != 13 {
+	if len(scripts) != 17 {
 		t.Fatalf("invalid the number of scripts, expect: 13, actual: %v", len(scripts))
 	}
 	fmt.Print(scripts["ZADDXP"])


### PR DESCRIPTION
```ZMRANGE``` read all keys in EXPIREAT. but for large table, this is redundant. For less consuming memory, we'd better to access each EXPIREAT by ```ZSCORE```